### PR TITLE
Add optional from_address field to SMTP config in backend and frontend

### DIFF
--- a/python/assign.py
+++ b/python/assign.py
@@ -41,7 +41,8 @@ def send_email(recipient_emails, subject, body, smtp_config=None):
         subject: Email subject
         body: Email body (HTML supported)
         smtp_config: Dictionary with SMTP configuration (required)
-                    {'server': 'smtp.gmail.com', 'port': 587, 'username': 'user@gmail.com', 'password': 'password'}
+                    {'server': 'smtp.gmail.com', 'port': 587, 'username': 'user@gmail.com', 'password': 'password', 'from_address': 'sender@example.com'}
+                    Note: 'from_address' is optional. If not provided, 'username' will be used as the from address.
     
     Returns:
         dict: Success status and detailed message
@@ -91,7 +92,7 @@ def send_email(recipient_emails, subject, body, smtp_config=None):
         
         # Create message
         msg = MIMEMultipart('alternative')
-        msg['From'] = smtp_config['username']
+        msg['From'] = smtp_config.get('from_address', smtp_config['username'])
         msg['Subject'] = subject
         
         # Add HTML body
@@ -134,7 +135,7 @@ def send_email(recipient_emails, subject, body, smtp_config=None):
             try:
                 msg['To'] = email
                 text = msg.as_string()
-                server.sendmail(smtp_config['username'], email, text)
+                server.sendmail(smtp_config.get('from_address', smtp_config['username']), email, text)
                 del msg['To']  # Remove To header for next iteration
             except smtplib.SMTPRecipientsRefused as e:
                 failed_emails.append({
@@ -461,7 +462,8 @@ def send_email_endpoint():
             "server": "smtp.gmail.com",
             "port": 587,
             "username": "sender@gmail.com",
-            "password": "app_password"
+            "password": "app_password",
+            "from_address": "noreply@example.com"  // Optional: if not provided, username will be used
         }
     }
     """

--- a/src/admin/vote/Email.tsx
+++ b/src/admin/vote/Email.tsx
@@ -69,6 +69,7 @@ interface SmtpConfig {
   server: string;
   port: number;
   username: string;
+  from_address?: string;
   password: string;
 }
 
@@ -385,6 +386,7 @@ export default function Email() {
           server: "smtp.gmail.com",
           port: 587,
           username: "",
+          from_address: "",
           password: "",
         };
   });
@@ -609,11 +611,17 @@ export default function Email() {
             );
 
             const studentResult = choice
-              ? results.find((r) => r.id === choice.id)
+              ? results.find((r) => r.id == choice.id)
               : null;
             const assignedOption = studentResult
-              ? options.find((o) => o.id === studentResult.assignedOption)
+              ? options.find((o) => o.id == studentResult.result)
               : null;
+
+            // DEBUG
+            console.log(
+              `Processing result for student ${student.name} (${student.listIndex})`
+            );
+            console.log(choice, studentResult, assignedOption);
 
             personalVariables = {
               ...personalVariables,
@@ -755,6 +763,21 @@ export default function Email() {
             setSmtpConfig({
               ...smtpConfig,
               username: (e.target as HTMLInputElement).value,
+            })
+          }
+          required
+        ></mdui-text-field>
+
+        <p />
+
+        <mdui-text-field
+          label="Absender-E-Mail"
+          placeholder="E-Mail-Adresse des Absenders"
+          value={smtpConfig.from_address || ""}
+          onInput={(e) =>
+            setSmtpConfig({
+              ...smtpConfig,
+              from_address: (e.target as HTMLInputElement).value,
             })
           }
           required


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a custom sender email address in SMTP settings.
  * Introduced a new field in the SMTP settings dialog for entering the sender's email address.

* **Documentation**
  * Updated documentation to describe the new optional sender email address field and its fallback behavior.

* **Style**
  * Improved debug logging for email sending operations.

* **Bug Fixes**
  * Adjusted comparison logic in email sending to improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->