### PR TITLE
Update firebase-tools dependency and commit workflow improvements

### DIFF
--- a/.github/workflows/firebase-hosting-commit.yml
+++ b/.github/workflows/firebase-hosting-commit.yml
@@ -35,6 +35,16 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Cache and install firebase-tools
+        uses: actions/cache@v4
+        id: cache-firebase-tools
+        with:
+          path: ~/.npm/_npx/
+          key: ${{ runner.os }}-firebase-tools-${{ hashFiles('package.json') }}
+      - if: steps.cache-firebase-tools.outputs.cache-hit != 'true'
+        name: Install firebase-tools (if not cached)
+        run: npm install -g firebase-tools
+
       - name: Build project
         run: pnpm run build
 
@@ -46,4 +56,3 @@ jobs:
           channelId: live
           projectId: waldorfwahlen
           target: waldorfwahlen
-

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
-    "firebase-tools": "14.14.0",
+    "firebase-tools": "^14.14.0",
     "globals": "^15.15.0",
     "rollup-plugin-visualizer": "^5.14.0",
     "vite": "^6.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,7 +112,7 @@ importers:
         specifier: ^0.4.20
         version: 0.4.20(eslint@9.29.0)
       firebase-tools:
-        specifier: 14.14.0
+        specifier: ^14.14.0
         version: 14.14.0(@types/node@24.0.4)(encoding@0.1.13)
       globals:
         specifier: ^15.15.0
@@ -8853,7 +8853,7 @@ snapshots:
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
-      string_decoder: 1.1.1
+      string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
   readable-stream@4.7.0:


### PR DESCRIPTION
Switch firebase-tools dependency to caret versioning for better compatibility and enhance the commit workflow with caching for faster installations.